### PR TITLE
Target v2 of Modrinth publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           ls -d ${{ matrix.loader }}/build/libs/*.jar | awk '{print length($1), $1}' | sort -nk 1 | head -1 | sed -n -r "s/^[0-9]+ (.+)$/\1/p" | xargs -I {} echo "ARTIFACT_FILE={}" >> $GITHUB_ENV
 
       - name: Publish to Modrinth
-        uses: cloudnode-pro/modrinth-publish@2.0.0
+        uses: cloudnode-pro/modrinth-publish@v2
         with:
           token: ${{ secrets.MODRINTH_TOKEN }}
           project: aPp6zuxU


### PR DESCRIPTION
Hi! Thanks for using modrinth-publish. To benefit from backwards-compatible SemVer patch & minor releases, we now recommend targeting `v2`.

Alternatively, you can set up [`.github/dependabot.yaml`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) to open a pull request to update to specific versions as they are released.

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
```